### PR TITLE
Fix debug build due to undefined "z_error" and "z_verbose" in zlib

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -513,10 +513,10 @@ ifeq ($(DEBUG), 1)
 			CXXFLAGS += -MDd
 		endif
 
-		CFLAGS += -Od -Zi -DDEBUG -D_DEBUG -DZLIB_DEBUG
+		CFLAGS += -Od -Zi -DDEBUG -D_DEBUG
 		CXXFLAGS += -Od -Zi -DDEBUG -D_DEBUG
 	else
-		CFLAGS += -O0 -g -DDEBUG -DZLIB_DEBUG
+		CFLAGS += -O0 -g -DDEBUG
 		CXXFLAGS += -O0 -g -DDEBUG
 	endif
 else


### PR DESCRIPTION
Update the submodule to contain the change:
https://github.com/libretro/libretro-deps/commit/cd1343ba90f54c2acda22923fd28a7c88c2c8947