### PR TITLE
Init m_image to NULL.

### DIFF
--- a/src/love/Types/Graphics/Font.h
+++ b/src/love/Types/Graphics/Font.h
@@ -46,7 +46,7 @@ class Font {
 	 */
 	int getWidth(const std::string& text);
 
-	Image* m_image;
+	Image* m_image = NULL;
 };
 
 }  // namespace Graphics


### PR DESCRIPTION
This fixes a segfault when closing chailove.

The root problem is that `tffFont` is never true as far as I can tell.

https://github.com/libretro/libretro-chailove/blob/7c72a5fd1ca9f55edc29d29bff9ab13ec353d641/src/love/Types/Graphics/Font.cpp#L120

And then `SDL_Surface* surface` is never set.

https://github.com/libretro/libretro-chailove/blob/7c72a5fd1ca9f55edc29d29bff9ab13ec353d641/src/love/Types/Graphics/Font.cpp#L122

Since `m_image` is not set to `NULL` this will be true when it should not be.

https://github.com/libretro/libretro-chailove/blob/7c72a5fd1ca9f55edc29d29bff9ab13ec353d641/src/love/Types/Graphics/Font.cpp#L71

Next it will crash here.

https://github.com/libretro/libretro-chailove/blob/7c72a5fd1ca9f55edc29d29bff9ab13ec353d641/src/love/Types/Graphics/Image.cpp#L20

And if that conditional is removed it will crash here instead.

https://github.com/libretro/libretro-chailove/blob/7c72a5fd1ca9f55edc29d29bff9ab13ec353d641/src/love/Types/Graphics/Image.cpp#L58

This can be simply avoided by making sure `m_image` is inited to `NULL`.

This might be further improved by fixing `ttyFont` and `ttfFont` so they are set, but I'm not sure how this should be done or what the ideal behavior would be...

@RobLoach Does this look good to you? I tested this with both the no content demo and Floppy Bird where it will no longer crash when closed.