### PR TITLE
Fix mingw cross compile and fix wii-u compile with newer devkitpro versions

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -572,7 +572,7 @@ CFLAGS += -D_CRT_SECURE_NO_DEPRECATE
 # Windows
 else
 	TARGET := $(TARGET_NAME)_libretro.dll
-	CC = gcc
+	CC ?= gcc
 	SHARED := -shared -static-libgcc -static-libstdc++ -s -Wl,--version-script=link.T
    PSS_STYLE :=2
 endif

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -261,7 +261,7 @@ else ifeq ($(platform), wiiu)
 	TARGET := $(TARGET_NAME)_libretro_$(platform).a
 	CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
 	AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
-	PLATFORM_DEFINES := -DGEKKO -DHW_RVL -mwup -mcpu=750 -meabi -mhard-float
+	PLATFORM_DEFINES := -DGEKKO -DHW_RVL -mcpu=750 -meabi -mhard-float
 	PLATFORM_DEFINES += -U__INT32_TYPE__ -U __UINT32_TYPE__ -D__INT32_TYPE__=int
 	ENDIANNESS_DEFINES += -DMSB_FIRST
 	STATIC_LINKING=1


### PR DESCRIPTION
Mingw cross compile still doesn't actually work due to something in the libretro-common inttypes detection flow.