### PR TITLE
ci: add a Linux aarch64 build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -39,6 +39,10 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-x64.yml'
 
+  # Linux ARM 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-aarch64.yml'
+
   # Linux 32-bit
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-i686.yml'
@@ -163,6 +167,12 @@ libretro-build-windows-i686:
 libretro-build-linux-x64:
   extends:
     - .libretro-linux-x64-make-default
+    - .core-defs
+
+# Linux ARM 64-bit
+libretro-build-linux-aarch64:
+  extends:
+    - .libretro-linux-aarch64-make-default
     - .core-defs
 
 # Linux 32-bit


### PR DESCRIPTION
The libretro buildbot ships no aarch64 Linux build of ChaiLove, so the core can't be installed from RetroArch's Core Downloader on ARM64 Linux machines (ARM Chromebooks, SBCs, ARM laptops). Nothing blocks it: there is no x86-specific code or flag in the build, and `android-arm64-v8a` and `osx-arm64` already build these sources for ARM64.

The job mirrors `libretro-build-linux-x64`:

```yaml
# Linux ARM 64-bit
libretro-build-linux-aarch64:
  extends:
    - .libretro-linux-aarch64-make-default
    - .core-defs
```

plus the matching `/linux-aarch64.yml` template include.

Verified natively on aarch64 (postmarketOS on a Snapdragon 670 Chromebook, glibc, GCC 15): `make platform=unix` builds clean with no source changes, producing `chailove_libretro.so` (ELF 64-bit ARM aarch64). In RetroArch 1.22.2 it loads `test/test.chailove` from this repo and runs the suite - 10094 frames at 320x240 / 60 fps, no dropped frames.
